### PR TITLE
docs: rewrite README and add AGENTS.md to reflect DiveVision's actual scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Project agent memory
+
+DiveVision has two current strands of work — see `README.md` for the full picture:
+
+1. **Experiment workflow**: testing/comparing underwater image enhancement models (U-Shape
+   Transformer, CE-VAE), benchmarked via MLflow on the LSUI/UIEB datasets.
+2. **Mobile app serving the tested models**: early stage. Only a minimal FastAPI endpoint exists
+   today (`divevision/src/app/main.py`); no mobile client, web app, social features, or
+   geolocation exist yet. Don't imply otherwise in docs or code comments.
+
+## Repo layout
+
+- `divevision/models/` — vendored third-party model implementations (U-Shape Transformer, CE-VAE).
+- `divevision/src/models/` — thin `AbstractModel` wrappers around those implementations
+  (`abstract_model.py`, `u_shape_model.py`, `cvae_model.py`).
+- `divevision/src/datasets/` — `AbstractDataset` implementations for LSUI and UIEB.
+- `divevision/src/metrics/` — SSIM/PSNR metrics used by the benchmark.
+- `divevision/src/test.py` — the MLflow benchmark pipeline (entry point via
+  `python -m divevision.src.test`).
+- `divevision/src/app/main.py` — the FastAPI serving endpoint.
+- `divevision/test/` — pytest suite for models and the FastAPI app.
+- `divevision/notebooks/test_model.ipynb` — manual smoke test for a model.
+
+## Running things
+
+- Tests: `poetry run pytest`
+- Benchmark: see "Running the benchmark" in `README.md` (needs `.env` + `./mlflow_server.sh`).
+- FastAPI server: `poetry run fastapi dev divevision/src/app/main.py`
+
+## Known issues
+
+- `download_resources.sh` only fetches model weights, not the LSUI/UIEB datasets themselves —
+  those must be obtained manually (see README's Installation section for expected paths).
+- The CE-VAE checkpoint download in `download_resources.sh` points to a dead Google Drive link
+  (404). U-Shape Transformer's weights download works.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,36 +1,93 @@
 # DiveVision
 
-This project aims at exploring solutions regarding **Underwater Image Restoration**.
+DiveVision explores solutions for **underwater image restoration / enhancement**. The project
+has two current strands of work:
 
-At this time, the goal is to use off-the-shelves models and test their performance on the [LSUI dataset](https://bianlab.github.io/data.html).
+1. **Experiment workflow** — testing and comparing underwater image enhancement models
+   (currently [U-Shape Transformer](https://github.com/LintaoPeng/U-shape_Transformer_for_Underwater_Image_Enhancement)
+   and [CE-VAE](https://github.com/iN1k1/ce-vae-underwater-image-enhancement)), benchmarked with
+   MLflow against the LSUI and UIEB datasets.
+2. **Mobile app serving the tested models** — very early stage. The current goal is simply to
+   serve a model's output to a mobile client. Social-network features and photo geolocation are
+   **future work**, not part of the current scope.
 
-The project will be enhanced, and here are some perspectives:
-- build and train a model (probably a ViT)
-- monitor the model performances (MLFlow?)
-- make a FastAPI server to serve the model
-- build a web app
-- build a mobile app
+## What exists today
+
+- **Model wrappers** for U-Shape Transformer and CE-VAE (`divevision/models/`,
+  `divevision/src/models/`), sharing a common `AbstractModel` interface
+  (`divevision/src/models/abstract_model.py`).
+- **A benchmark pipeline** (`divevision/src/test.py`) that runs each model against the LSUI and
+  UIEB datasets, computes SSIM/PSNR metrics, and logs runs to MLflow.
+- **A minimal FastAPI server** (`divevision/src/app/main.py`) with a single endpoint that accepts
+  an uploaded image and returns the U-Shape Transformer's enhanced output as a PNG. This is the
+  seed of the "serve a model to a client" mobile-app goal above — it is not yet wired up to any
+  mobile client.
+- **Tests** for the models and the FastAPI app (`divevision/test/`).
+
+## Roadmap (not implemented yet)
+
+- Training a model from scratch (the README previously implied this existed — it does not; only
+  inference over pretrained checkpoints is implemented).
+- A dedicated web app.
+- A real mobile app client consuming the FastAPI endpoint (or its successor).
+- Social-network features and photo geolocation — explicitly out of scope until the above lands.
 
 ## Installation
 
 ### Prerequisites
 
-Python 3.12<br>
-[Poetry](https://python-poetry.org/)<br>
-Clone the repository
+- Python 3.12
+- [Poetry](https://python-poetry.org/)
+- Clone the repository
 
 ### Steps
 
-1. ```poetry install```
-2. Download necessary resources by runing ```./download_resources.sh```
-3. Try and run the notebook `test_model.ipynb` to see if everything is working, using the poetry environment
+1. `poetry install`
+2. Download pretrained model weights: `./download_resources.sh`
+   - This fetches only **model weights**, not the datasets (see below).
+   - **Known issue:** the CE-VAE checkpoint download (`lsui-cevae-epoch119.ckpt`, via Google
+     Drive) currently returns a 404 — the link is dead. `download_resources.sh` will appear to
+     run but the CE-VAE model will be left without weights. The U-Shape Transformer weights
+     download works. Track/fix the CE-VAE link before relying on CE-VAE results.
+3. Download the datasets yourself — **this is not automated by any script in this repo**:
+   - [LSUI dataset](https://bianlab.github.io/data.html) — expected at `divevision/data/LSUI/`,
+     with `GT/` and `input/` subdirectories (see `divevision/src/datasets/lsui_dataset.py`).
+   - [UIEB dataset](https://li-chongyi.github.io/proj_benchmark.html) — expected at
+     `divevision/data/UIEB/`, with `raw-890/` and `reference-890/` subdirectories (see
+     `divevision/src/datasets/uieb_dataset.py`). Academic use only, per the dataset's terms.
+4. Try the notebook `divevision/notebooks/test_model.ipynb` to check that a model runs
+   end-to-end, using the poetry environment.
+
+## Running the benchmark
+
+`divevision/src/test.py` runs both models against both datasets and logs metrics to MLflow.
+
+1. Copy `.env_example` to `.env` and fill in the MLflow/Supabase/S3 variables it expects.
+2. Start an MLflow tracking server: `./mlflow_server.sh` (reads `.env`, backs onto a Supabase
+   Postgres DB and S3-compatible storage for run/artifact storage).
+3. Run the benchmark: `poetry run python -m divevision.src.test`
+
+## Running the FastAPI server
+
+```
+poetry run fastapi dev divevision/src/app/main.py
+```
+
+This exposes a form at `/` to upload an image and a `POST /image/` endpoint that returns the
+U-Shape Transformer's enhanced PNG output. There is no mobile client in this repository yet.
+
+## Running tests
+
+```
+poetry run pytest
+```
 
 ## Resources
 
-- **U-Shape Transformer for Underwater Image Enhancement. Peng L., Zhu C., Bian L., 2021**
-    - [Github](https://github.com/LintaoPeng/U-shape_Transformer_for_Underwater_Image_Enhancement)
-    - [Paper](https://arxiv.org/abs/2111.11843)
-
-- **CE-VAE: Capsule Enhanced Variational AutoEncoder for Underwater Image Enhancement. Pucci R., Martinal N., 2024**
-    - [Github](https://github.com/iN1k1/ce-vae-underwater-image-enhancement)
-    - [Paper](https://arxiv.org/pdf/2406.01294v2)
+- **U-Shape Transformer for Underwater Image Enhancement.** Peng L., Zhu C., Bian L., 2021.
+  [Github](https://github.com/LintaoPeng/U-shape_Transformer_for_Underwater_Image_Enhancement) —
+  [Paper](https://arxiv.org/abs/2111.11843)
+- **CE-VAE: Capsule Enhanced Variational AutoEncoder for Underwater Image Enhancement.** Pucci R.,
+  Martinal N., 2024.
+  [Github](https://github.com/iN1k1/ce-vae-underwater-image-enhancement) —
+  [Paper](https://arxiv.org/pdf/2406.01294v2)


### PR DESCRIPTION
## Intent

Rewrite README.md and create/update AGENTS.md for DiveVision to reflect its actual two-fold aim: (1) an experiment workflow for testing/comparing underwater image enhancement models (U-Shape Transformer, CE-VAE) benchmarked via MLflow on LSUI/UIEB datasets, and (2) an early-stage mobile app serving a tested model's output (social features and geolocation are explicitly future work, not current scope). Ground the docs in the actual repo: document the existing MLflow benchmark pipeline (divevision/src/test.py, mlflow_server.sh) and the minimal FastAPI serving endpoint (divevision/src/app/main.py), neither previously documented. Do not describe training, a web app, or a real mobile app as implemented - frame them as roadmap only. Fix or clearly flag the gap that no script documents how to obtain the LSUI/UIEB datasets themselves (only model weights are fetched by download_resources.sh). Flag the CE-VAE model checkpoint download as broken (dead Google Drive link, verified 404) rather than presenting it as working. Create a lean AGENTS.md (contributor-facing, not a README copy) covering the two-fold aim, repo layout at a glance, how to run tests/benchmark/FastAPI server, with pointers rather than copied detail for anything the code already shows. Documentation-only: do not implement Docker or Supabase support (separate sibling tasks own DiveVision issues #7 and #4).

## What Changed

- Rewrote `README.md` to describe DiveVision's two actual strands of work (the MLflow experiment/benchmark workflow and the early-stage FastAPI serving endpoint), replacing the old aspirational roadmap language; added sections documenting the benchmark pipeline (`divevision/src/test.py`, `mlflow_server.sh`) and the FastAPI server (`divevision/src/app/main.py`), neither previously documented.
- Documented in the README that `download_resources.sh` only fetches model weights (not the LSUI/UIEB datasets, which must be obtained manually) and flagged the CE-VAE checkpoint's Google Drive download link as dead (404), while noting the U-Shape Transformer weights download works.
- Added `AGENTS.md` with a lean, contributor-facing summary of the project's two-fold aim, repo layout, and commands for running tests/benchmark/FastAPI server, plus a symlinked `CLAUDE.md` pointing to it.

## Risk Assessment

✅ Low: Documentation-only change (README.md, AGENTS.md, CLAUDE.md symlink); every factual claim was cross-checked against actual source (download_resources.sh, .env_example, mlflow_server.sh, dataset classes, main.py, test.py) and matches, and all required-vs-forbidden constraints from the user intent are satisfied with no Docker/Supabase implementation added.

## Testing

This is a documentation-only diff (README.md, AGENTS.md, CLAUDE.md symlink) with zero application code changes, so I validated it by cross-checking every factual claim in the new docs against the live repository and, where possible, live external state — rather than by running the app, since no behavior changed. All checks passed: every file path cited exists, the "no dataset download script" gap is real, the CE-VAE checkpoint link genuinely 404s right now (verified live), the FastAPI endpoint description matches main.py's actual code exactly, and training/web-app/mobile-app are correctly scoped as roadmap-only with no Docker/Supabase implementation added. The one gap is that I could not execute the existing `test_app.py` (which exercises the same GET // POST /image/ endpoints the README now documents) because this environment lacks poetry and the ML dependencies (torch, fastapi, etc.); installing them would require multi-GB downloads unrelated to validating a docs change, so I relied on direct source-code comparison instead, which fully confirms the documented behavior.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f8120e67e02a7f839a839017da4a685d88b7acd4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Manual check: `for f in divevision/src/test.py mlflow_server.sh divevision/src/app/main.py ... ; do [ -e &#34;$f&#34; ]; done` — confirmed every file path cited in README.md/AGENTS.md exists in the repo</code>
- <code>Manual check: `grep -riln &#34;LSUI|UIEB&#34; --include=*.sh .` and `find . -iname &#39;*download*&#39;` — confirmed download_resources.sh is the only download script and does not fetch datasets, matching the documented gap</code>
- <code>Live network check: `curl -s -o /dev/null -w &#39;%{http_code}&#39; -L &lt;CE-VAE gdown URL from download_resources.sh&gt;` — returned 404, confirming the README/AGENTS.md claim that the CE-VAE checkpoint link is dead is currently true, not stale</code>
- `Read divevision/src/app/main.py and compared line-by-line against README's 'Running the FastAPI server' section — GET / returns the upload form HTML, POST /image/ returns a PNG via UShapeModelWrapper, exactly as documented`
- `Read mlflow_server.sh and .env_example and compared against README's benchmark section — confirmed it reads .env and connects to a Supabase Postgres backend with S3-related env vars, matching the documented claim`
- <code>Attempted `poetry run pytest divevision/test/test_app.py -v` (the existing test that exercises the documented FastAPI endpoints end-to-end) — could not run: poetry is not installed and system Python lacks fastapi/pytest; running it would require a full poetry install (torch, mlflow, lightning, etc.) plus downloaded model weights, disproportionate to a docs-only change with no application code modified</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
