### PR TITLE
ci: retarget workflow triggers from main to dev

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,9 +5,9 @@ name: Python application
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "dev" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "dev" ]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- The only GitHub Actions workflow, `.github/workflows/python-app.yml`, triggered only on `push`/`pull_request` to `branches: [ "main" ]`, but this repo's real default/integration branch is `dev` — every PR (including every current in-flight one) targets `dev`, so CI never fired at all.
- Confirmed live: PR #8 sat for hours with no checks ever starting, and its `no-mistakes` validation eventually failed at its own `ci` step because of it.
- Retargets both the `push:` and `pull_request:` triggers to `branches: [ "dev" ]`. No other changes to the workflow (no new jobs, no new triggers).

This was a deliberate, narrow fix — a heavier two-tier CI split was discussed and rejected as premature for an early-stage project with no `main` branch or release process.

Once merged, this is expected to also unblock CI on the three other currently-open DiveVision PRs, since they all target `dev` too.

## Test plan
- [ ] Confirm CI now runs on this PR (targets `dev`)