### PR TITLE
Add domain model (CONTEXT.md) for the experiment/benchmark workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,8 @@
 # Project agent memory
 
+For domain vocabulary (Enhancement Model, Benchmark Dataset, Reference Image, etc.), see
+`CONTEXT.md`. Architectural decisions are recorded in `docs/adr/`.
+
 DiveVision has two current strands of work — see `README.md` for the full picture:
 
 1. **Experiment workflow**: testing/comparing underwater image enhancement models (U-Shape

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,82 @@
+# DiveVision — Underwater Image Enhancement
+
+DiveVision's current, code-backed scope is a research workflow for testing and comparing
+underwater image enhancement models: paired benchmark datasets, model wrappers around
+third-party architectures, quality metrics, and MLflow-based experiment tracking. The
+mobile app / web app / FastAPI-serving strand mentioned in the README is out of scope for
+this model — today it is a single unwrapped endpoint with no domain vocabulary of its own
+yet (see "Out of scope" below).
+
+## Language
+
+### Images
+
+**Degraded Image**:
+An underwater photograph exhibiting color cast, haze, or contrast loss, before enhancement. The
+input half of a paired sample in a Benchmark Dataset (e.g. LSUI's `input/`, UIEB's `raw-890/`).
+_Avoid_: input image, raw image
+
+**Reference Image**:
+The clean, color-corrected counterpart to a Degraded Image, used as ground truth when scoring an
+Enhanced Image (e.g. LSUI's `GT/`, UIEB's `reference-890/`).
+_Avoid_: GT, ground truth, label, target
+
+**Enhanced Image**:
+The image an Enhancement Model produces by running its predict step on a Degraded Image.
+_Avoid_: output image, restored image, prediction
+
+### Models
+
+**Enhancement Model**:
+A wrapped, invokable model that maps a Degraded Image to an Enhanced Image, registered under a
+short name (e.g. `"U-Shape"`, `"CVAE"`) and implementing the common `AbstractModel` interface
+(`preprocessing` → forward pass → `postprocessing`). Currently two exist: U-Shape Transformer and
+CE-VAE.
+_Avoid_: model (ambiguous with Model Implementation below), network
+
+**Model Implementation**:
+The vendored third-party architecture code an Enhancement Model wraps unmodified
+(`divevision/models/`), kept close to its upstream source so it stays diffable against the
+original research repo. An Enhancement Model adapts one Model Implementation to the project's
+common interface; the two are never the same object.
+_Avoid_: model, wrapper (that's the Enhancement Model's role, not the implementation's)
+
+**Checkpoint**:
+The trained weights file an Enhancement Model loads into its Model Implementation before it can
+run. Fetched separately from code, either via `download_resources.sh` (U-Shape Transformer) or a
+config-referenced path (CE-VAE); an Enhancement Model without its Checkpoint present still
+constructs but warns and runs with untrained weights.
+_Avoid_: weights (fine as prose, but prefer Checkpoint as the noun for "the file")
+
+### Data and evaluation
+
+**Benchmark Dataset**:
+A paired collection of Degraded Images and their corresponding Reference Images, used to evaluate
+Enhancement Models. Currently LSUI and UIEB.
+_Avoid_: dataset (only when precision matters — otherwise fine as shorthand)
+
+**Evaluation Metric**:
+A scoring function that compares an Enhanced Image against its Reference Image and produces a
+numeric quality score. Currently SSIM and PSNR.
+_Avoid_: score, measure
+
+### Experiment tracking
+
+**Experiment**:
+The top-level MLflow container that groups every Benchmark Run for a given purpose (currently one
+Experiment, `"Model testing"`, holds all of them).
+_Avoid_: run (a Run is one execution inside an Experiment, not the container)
+
+**Benchmark Run**:
+One MLflow Run: the execution of one Enhancement Model against one full Benchmark Dataset,
+producing per-batch and aggregate Evaluation Metric values plus elapsed-time figures logged to
+MLflow.
+_Avoid_: experiment (too broad — see Experiment above), test
+
+## Out of scope
+
+The FastAPI endpoint (`divevision/src/app/main.py`) and the mobile/web app it is meant to
+eventually serve are early-stage and not modeled here. Today the endpoint is a single hard-coded
+call to the U-Shape Enhancement Model with no client, no user or account concept, and no
+persistence — there isn't yet a domain to name beyond the terms above. Revisit this file when
+that strand grows real vocabulary (uploads, accounts, storage, etc.).

--- a/docs/adr/0001-mlflow-tracking-on-supabase.md
+++ b/docs/adr/0001-mlflow-tracking-on-supabase.md
@@ -1,0 +1,11 @@
+# MLflow tracking backend runs on Supabase Postgres + S3-compatible storage
+
+`mlflow_server.sh` points MLflow's backend store at a Supabase-hosted Postgres database and its
+artifact store at S3-compatible storage (`.env_example`'s `SUPABASE_POSTGRES_*` and `AWS_*`
+variables), instead of MLflow's default local file store. This is a deliberate choice to run
+Benchmark Runs against shared, durable infrastructure from the start rather than local SQLite/disk
+storage, and it reuses the same Supabase project the app strand is expected to depend on for
+storage and auth later (see issue #4), rather than standing up separate infrastructure for
+experiment tracking alone.
+
+Reversing this later means migrating existing MLflow run history, not just a config change.


### PR DESCRIPTION
## Summary

Runs the `mattpocock-skills:domain-modeling` skill against the current codebase (not the README's future roadmap) and produces `CONTEXT.md` at the repo root, plus one ADR.

**Vocabulary captured** (`CONTEXT.md`):

- **Images**: `Degraded Image` (the raw underwater photo) → `Enhancement Model` → `Enhanced Image`, scored against a `Reference Image` (ground truth). This canonicalizes on one term per concept where the code currently uses several (`input`/`raw`, `GT`/`label`/`target`/`reference`).
- **Models**: `Enhancement Model` (the `AbstractModel` wrapper, e.g. U-Shape, CVAE) is distinguished from the `Model Implementation` it wraps (vendored third-party code in `divevision/models/`) — these are two different things both casually called "model" in the code/docs. Also defines `Checkpoint` (the weights file a model needs to run for real).
- **Data & evaluation**: `Benchmark Dataset` (paired Degraded/Reference images — LSUI, UIEB) and `Evaluation Metric` (SSIM, PSNR).
- **Experiment tracking**: disambiguates MLflow's `Experiment` (the container, `"Model testing"`) from a `Benchmark Run` (one model × one dataset execution) — the code calls both loosely "run"/"experiment" interchangeably in places.

**Out of scope, called out explicitly**: the FastAPI endpoint and future mobile/web app — today it's one hard-coded endpoint with no client, accounts, or persistence, so there's no domain to name there yet.

**ADR 0001**: records why MLflow's backend store runs on Supabase-hosted Postgres + S3-compatible storage instead of local storage — it's a real, hard-to-reverse infra choice (would need a run-history migration to undo) that isn't explained elsewhere in the repo, and it lines up with the Supabase dependency the future app strand is expected to need (issue #4).

Also added a one-line pointer from `AGENTS.md`/`CLAUDE.md` to `CONTEXT.md` and `docs/adr/`.

## Test plan

- [x] `CONTEXT.md` reviewed against the actual code in `divevision/src/{models,datasets,metrics}/` and `divevision/src/test.py` (not just the README) for accuracy.
- [x] No implementation details leaked into `CONTEXT.md` (glossary only, per the skill's format).
- N/A — this is a docs-only change; no code/tests to run.