### PR TITLE
fix(app): delete orphaned original photo when create_photo insert fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Ignore the data folder
 divevision/data/*/
 
-# LPIPS checkpoint download cache (see divevision/src/models/CEVAE/modules/losses/lpips.py)
+# LPIPS checkpoint download cache (see divevision/models/CEVAE/modules/losses/lpips.py)
 taming/
 
 # Ignore VS Code cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Ignore the data folder
 divevision/data/*/
 
+# LPIPS checkpoint download cache (see divevision/src/models/CEVAE/modules/losses/lpips.py)
+taming/
+
 # Ignore VS Code cache
 .vscode/*
 

--- a/divevision/src/app/main.py
+++ b/divevision/src/app/main.py
@@ -114,6 +114,9 @@ async def upload_file(
         access_token, refresh_token, original_path, model.name
     )
     if photo_id is None:
+        supabase_api.delete_image(
+            access_token, refresh_token, original_path, supabase_api.IMAGES_BUCKET
+        )
         raise HTTPException(status_code=502, detail="Could not record the photo")
 
     # Store the processed result under the same relative path as the original.

--- a/divevision/test/test_app.py
+++ b/divevision/test/test_app.py
@@ -163,6 +163,49 @@ def test_upload_image_marks_failed_when_processed_upload_fails(monkeypatch):
     assert failed == ["photo-1"]
 
 
+def test_upload_image_deletes_original_when_create_photo_fails(monkeypatch):
+    random_image = Image.fromarray(np.zeros((128, 128, 3), dtype=np.uint8), mode="RGB")
+    buffer = io.BytesIO()
+    random_image.save(buffer, "PNG")
+
+    def fake_predict(self, image):
+        image.load()
+        return [image]
+
+    fake_model = type("FakeModel", (), {"name": "U-Shape", "predict": fake_predict})()
+    monkeypatch.setattr(
+        "divevision.src.app.main.UShapeModelWrapper", lambda: fake_model
+    )
+
+    monkeypatch.setattr(
+        supabase_api,
+        "upload_image",
+        lambda access_token, refresh_token, file, bucket, path=None: "user-123/original.jpg",
+    )
+    monkeypatch.setattr(
+        supabase_api,
+        "create_photo",
+        lambda access_token, refresh_token, original_path, model_name: None,
+    )
+    deleted = []
+    monkeypatch.setattr(
+        supabase_api,
+        "delete_image",
+        lambda access_token, refresh_token, path, bucket: deleted.append(
+            (path, bucket)
+        ),
+    )
+
+    response = client.post(
+        "/image/",
+        files={"file": ("foo.png", buffer.getvalue(), "image/png")},
+        headers=AUTH_HEADERS,
+    )
+
+    assert response.status_code == 502
+    assert deleted == [("user-123/original.jpg", supabase_api.IMAGES_BUCKET)]
+
+
 def test_delete_photo(monkeypatch):
     monkeypatch.setattr(
         supabase_api,

--- a/taming/modules/autoencoder/lpips/vgg.pth
+++ b/taming/modules/autoencoder/lpips/vgg.pth
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a78928a0af1e5f0fcb1f3b9e8f8c3a2a5a3de244d830ad5c1feddc79b8432868
+size 7289

--- a/taming/modules/autoencoder/lpips/vgg.pth
+++ b/taming/modules/autoencoder/lpips/vgg.pth
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a78928a0af1e5f0fcb1f3b9e8f8c3a2a5a3de244d830ad5c1feddc79b8432868
-size 7289


### PR DESCRIPTION
## Intent

Resume DiveVision issue #4: add Supabase-backed auth and photo storage for the mobile app track. Design (settled across two rounds of review, not to be re-litigated): the app gets its own fresh, empty Supabase project in the EU region, kept separate from the existing MLflow-related Supabase project (that one is a sibling concern and out of scope). Adds a minimal photos table. Supports per-photo delete and full-account delete (GDPR erasure). Signup is open self-serve. The upload/processing flow stays synchronous - no Edge Function, no job queue; POST /image/ persists both the original and processed photo plus a photos row as a side effect of the existing synchronous upload-and-return flow. Adds a shared-secret-protected POST /leaderboard endpoint fed by local MLflow runs writing into the app DB - the Supabase service-role key never leaves the app backend. This redesign supersedes an earlier in-place-patch approach that targeted the old shared Supabase project and had an RLS cross-tenant exposure bug (MLflow-adjacent policies leaking access to user photos); the earlier approach is abandoned, not something to build on or merge with. supabase_api.py creates a fresh client per call rather than sharing one module-level client so one user's session can never leak into a concurrent request for another user. Every per-user table/bucket is RLS-scoped to auth.uid() with no blanket permissive policies alongside a scoped one. DELETE /account/ relies on photos.user_id's ON DELETE CASCADE FK to clean up rows once the auth user is deleted, and explicitly removes storage objects first. Implementation is already complete and was previously validated end-to-end against a local supabase start stack (signup -> login -> upload -> leaderboard -> account-delete). A prior no-mistakes run on this same commit crashed due to an infrastructure/daemon failure mid-fix (not a real code-quality finding) while fixing two legitimate issues: missing supabase/storage3 dependencies in pyproject.toml breaking app import, and a hardcoded image/jpeg content-type on uploads - those still need to be fixed for real. Goal now: get this already-implemented, already-designed work through no-mistakes validation to a green PR that closes issue #4.

## What Changed

- `POST /image/` now deletes the just-uploaded original photo from storage when the `create_photo` DB insert fails, instead of leaving an orphaned object with no `photos` row.
- Added `taming/` to `.gitignore` (LPIPS checkpoint download cache) and corrected the comment pointing to `divevision/models/CEVAE/modules/losses/lpips.py`.
- Added a test covering the orphan-cleanup path: verifies the original image is deleted from the images bucket and the endpoint still returns 502 when `create_photo` returns `None`.

## Risk Assessment

✅ Low: This fix round cleanly resolves both prior findings — removes the accidentally-committed LPIPS checkpoint (with a matching .gitignore entry) and adds a behavior-level test for the orphan-cleanup path — without introducing new risk or touching unrelated code.

## Testing

Ran the targeted FastAPI app test suite (divevision/test/test_app.py), all 17 tests pass, and confirmed via a revert/restore cycle that the new orphan-cleanup test actually fails without the main.py fix and passes with it — proving it's a genuine regression test rather than a superficial check. The two dependency/content-type concerns flagged in the user intent as outstanding were already fixed in commits preceding the base commit, so they're outside this delta's scope and required no action here.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"015ef3c9496523333309e6a43fd5ba6543c8684f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `taming/modules/autoencoder/lpips/vgg.pth:1` - This commit adds `taming/modules/autoencoder/lpips/vgg.pth`, a git-lfs pointer to a VGG LPIPS checkpoint. This path is a runtime download cache used by `divevision/src/models/CEVAE/modules/losses/lpips.py` (`get_ckpt_path(name, &#34;taming/modules/autoencoder/lpips&#34;)`), not a source file — it isn&#39;t referenced anywhere else, `taming/` didn&#39;t exist in the repo before this commit, and it&#39;s unrelated to both the stated commit purpose (orphaned-photo cleanup) and the auth/photo-storage feature. It was almost certainly staged accidentally after a local test run downloaded the checkpoint (e.g. via `git add -A`). It should be removed from the commit and the `taming/` cache dir added to `.gitignore` instead.
- ℹ️ `divevision/src/app/main.py:117` - The new orphan-cleanup branch (delete the original image when `create_photo` fails) has no test coverage, unlike the sibling failure path a few lines below (`test_upload_image_marks_failed_when_processed_upload_fails`) which does verify its cleanup call. Worth adding an analogous test that asserts `delete_image` is invoked with the original path when `create_photo` returns `None`.

🔧 Fix: Remove accidental taming/ checkpoint, add orphan-cleanup test coverage
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `poetry run pytest divevision/test/test_app.py -v (17 passed, including new test_upload_image_deletes_original_when_create_photo_fails)`
- `Regression check: reverted the delete_image call in divevision/src/app/main.py and reran test_upload_image_deletes_original_when_create_photo_fails alone — it failed (asserting deleted == [] vs expected orphan cleanup), confirming the new test genuinely exercises the fix; restored the fix and confirmed it passes again`
- `grep pyproject.toml/poetry.lock for supabase/storage3 to confirm the dependency (fixed pre-base in d9eb148) is present and app imports successfully during pytest collection`
- `Verified _detect_content_type in divevision/src/app/supabase_api.py sniffs real image format instead of hardcoding image/jpeg (pre-existing fix, not part of this delta)`
- `git status / ls taming/ to confirm no stray checkpoint artifact and a clean working tree after testing`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
