### PR TITLE
fix(resources): re-host CE-VAE checkpoint as a GitHub Release asset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,10 @@ DiveVision has two current strands of work — see `README.md` for the full pict
 
 - `download_resources.sh` only fetches model weights, not the LSUI/UIEB datasets themselves —
   those must be obtained manually (see README's Installation section for expected paths).
-- The CE-VAE checkpoint download in `download_resources.sh` points to a dead Google Drive link
-  (404). U-Shape Transformer's weights download works.
+- The CE-VAE checkpoint (`lsui-cevae-epoch119.ckpt`) is fetched from a GitHub Release asset
+  (`cevae-checkpoint-v1` tag on this repo) rather than the old, dead Google Drive link. If it
+  ever needs re-hosting, upload a new asset via `gh release upload` and update the URL in
+  `download_cevae_resources`.
 
 ## Supabase: two separate projects
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,9 @@ has two current strands of work:
 1. `poetry install`
 2. Download pretrained model weights: `./download_resources.sh`
    - This fetches only **model weights**, not the datasets (see below).
-   - **Known issue:** the CE-VAE checkpoint download (`lsui-cevae-epoch119.ckpt`, via Google
-     Drive) currently returns a 404 — the link is dead. `download_resources.sh` will appear to
-     run but the CE-VAE model will be left without weights. The U-Shape Transformer weights
-     download works. Track/fix the CE-VAE link before relying on CE-VAE results.
+   - The CE-VAE checkpoint (`lsui-cevae-epoch119.ckpt`) is fetched from a GitHub Release asset
+     on this repo (`cevae-checkpoint-v1` tag), and the U-Shape Transformer weights from Google
+     Drive.
 3. Download the datasets yourself — **this is not automated by any script in this repo**:
    - [LSUI dataset](https://bianlab.github.io/data.html) — expected at `divevision/data/LSUI/`,
      with `GT/` and `input/` subdirectories (see `divevision/src/datasets/lsui_dataset.py`).

--- a/download_resources.sh
+++ b/download_resources.sh
@@ -17,7 +17,7 @@ function download_cevae_resources () {
     wget -P divevision/models/CEVAE/metrics/ https://raw.githubusercontent.com/xinntao/EDVR/master/basicsr/metrics/niqe_pris_params.npz
     
     # Model weights
-    poetry run gdown -O divevision/models/CEVAE/lsui-cevae-epoch119.ckpt https://drive.google.com/uc?id=1EJHykrwPqegmdWsrAT2Qd8ScYs7flX-i&confirm=t&uuid=197f6233-5f60-4fa9-81ab-af8e2a53d061 &
+    wget -O divevision/models/CEVAE/lsui-cevae-epoch119.ckpt https://github.com/ahennequin/DiveVision/releases/download/cevae-checkpoint-v1/lsui-cevae-epoch119.ckpt &
 }
 
 download_u_shape_transformer_resources


### PR DESCRIPTION
## Intent

Fix the CE-VAE checkpoint download in download_resources.sh: the download_cevae_resources function's gdown/Google Drive link for lsui-cevae-epoch119.ckpt (~1.02GB) returns a 404, per README's Installation Known-issue note and AGENTS.md's Known issues section. Re-host a known-working copy of the checkpoint and fix the script so a fresh ./download_resources.sh run succeeds with no dead-link failure.

Work done: uploaded the checkpoint (from a read-only local source outside this worktree, sha256 8124eb58d8f0259649ddf25b013d18e4acf9c1a2e830a9a0aee9055c65543d18, 1093904717 bytes) as a GitHub Release asset on this repo under tag cevae-checkpoint-v1, with a release body describing what the asset is and noting the filename must not be renamed since the download script references it by exact URL. Changed download_cevae_resources in download_resources.sh to wget the checkpoint from that Release asset's browser_download_url instead of the old gdown/Google Drive line, matching the wget-based reliability of the already-working U-Shape Transformer weights download (that download itself still uses gdown, so the change here is specifically switching CE-VAE off gdown/Google Drive onto a stable GitHub Release asset URL, not literally copying U-Shape's command). Verified the new URL end-to-end before finishing: wget --spider returned 200 with the correct Content-Length, and a full download of the asset was byte-for-byte checksum-identical (sha256) to the known-good local source file. Updated the Known-issue note in README.md's Installation section and the Known issues entry in AGENTS.md (CLAUDE.md is a symlink to AGENTS.md) to remove the dead-link description and instead document that the CE-VAE checkpoint now comes from the cevae-checkpoint-v1 GitHub Release asset, including how to re-host it in the future if needed.

## What Changed
- `download_resources.sh`: `download_cevae_resources` now fetches `lsui-cevae-epoch119.ckpt` via `wget` from the `cevae-checkpoint-v1` GitHub Release asset on this repo, replacing the dead `gdown`/Google Drive link.
- `README.md`: Installation's Known-issue note is replaced with a description of the new GitHub Release asset source (U-Shape Transformer weights remain on Google Drive).
- `AGENTS.md`: Known issues entry updated to document the new checkpoint source and how to re-host it via `gh release upload` if needed in the future.

## Risk Assessment

✅ Low: Small, well-bounded 3-file diff (a URL swap plus matching doc updates) that I verified end-to-end: the GitHub Release asset exists under the exact tag/filename referenced by the script, its size matches the intent's stated byte count, and a live spider request returns 200 with the correct Content-Length, so the dead-link failure is genuinely fixed with no new risk introduced.

## Testing

No automated tests exist for this shell script (nothing in divevision/test references download_resources.sh or cevae), so I manually exercised the actual fixed code path: downloaded the new GitHub Release asset URL exactly as download_cevae_resources now invokes it, confirmed HTTP 200 with the expected Content-Length, then fully downloaded it and verified the sha256 matched the checksum the author reported for the known-good source (1093904717 bytes). README.md and AGENTS.md (symlinked as CLAUDE.md) were updated consistently to drop the dead-link known-issue note. All downloaded verification artifacts were removed from /tmp afterward and the worktree is clean; a short verification log was written to the evidence directory.

<details>
<summary>Evidence: CE-VAE checkpoint re-host verification (spider check + full download + sha256 match)</summary>

```text
Verification of CE-VAE checkpoint re-host (branch fm/divevision-cevae-checkpoint)
===================================================================================

Command under test (download_resources.sh, download_cevae_resources):
  wget -O divevision/models/CEVAE/lsui-cevae-epoch119.ckpt \
    https://github.com/ahennequin/DiveVision/releases/download/cevae-checkpoint-v1/lsui-cevae-epoch119.ckpt

1) wget --spider (HEAD-equivalent) against the Release asset URL:
   HTTP/1.1 302 -> redirected to release-assets.githubusercontent.com
   HTTP/1.1 200 OK
   Content-Length: 1093904717
   "Remote file exists."

2) Full download of the asset (to /tmp, outside the worktree, then removed):
   File size: 1093904717 bytes (matches intent's stated 1093904717 bytes)
   sha256:    8124eb58d8f0259649ddf25b013d18e4acf9c1a2e830a9a0aee9055c65543d18
   Matches the sha256 stated in the user intent as the known-good local source checksum.

3) Target directory divevision/models/CEVAE/ exists in the worktree, so the script's
   `wget -O divevision/models/CEVAE/lsui-cevae-epoch119.ckpt` will not fail on a missing
   parent directory.

4) Downloaded file removed from /tmp after verification; `git status --short` in the
   worktree is clean (no artifacts left behind).

Conclusion: a fresh ./download_resources.sh run will download a checksum-verified,
byte-identical copy of the CE-VAE checkpoint from the GitHub Release asset instead of
hitting the old dead Google Drive link.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"65b9535b53216f7586d0a1729f2ec410c4813742","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`wget --spider -S https://github.com/ahennequin/DiveVision/releases/download/cevae-checkpoint-v1/lsui-cevae-epoch119.ckpt` — got HTTP 200 with Content-Length 1093904717 after the expected redirect to release-assets.githubusercontent.com</code>
- <code>Full download of the asset to /tmp (outside worktree) via the exact wget invocation now used in download_resources.sh&#39;s download_cevae_resources, followed by `sha256sum` — result 8124eb58d8f0259649ddf25b013d18e4acf9c1a2e830a9a0aee9055c65543d18, 1093904717 bytes, matching the checksum/size the author reported verifying against the known-good local source</code>
- <code>Confirmed `divevision/models/CEVAE/` exists in the worktree so the script&#39;s `-O divevision/models/CEVAE/lsui-cevae-epoch119.ckpt` target path won&#39;t fail on a missing parent directory</code>
- <code>Confirmed `CLAUDE.md` is a symlink to `AGENTS.md` (`readlink CLAUDE.md` -&gt; AGENTS.md), consistent with the intent&#39;s claim that editing AGENTS.md updates both</code>
- <code>`git diff bf09269 65b9535 -- download_resources.sh README.md AGENTS.md CLAUDE.md` to confirm the script, README Known-issue note, and AGENTS.md Known issues entry were all updated consistently to remove the dead-link description</code>
- <code>`git status --short` after cleanup to confirm no downloaded artifacts were left in the worktree</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
